### PR TITLE
Configures publishing to Maven Central

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -1,0 +1,97 @@
+name: Publish to Maven Central
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.1.1)'
+        required: true
+        type: string
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - release
+          - snapshot
+        default: release
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      
+    - name: Import GPG key
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      run: |
+        echo "$GPG_PRIVATE_KEY" | base64 -d | gpg --batch --import
+        echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+        gpgconf --kill gpg-agent
+        
+    - name: Update version
+      if: github.event.inputs.release_type == 'release'
+      run: |
+        sed -i "s/version = '.*'/version = '${{ github.event.inputs.version }}'/" build.gradle
+        
+    - name: Update SNAPSHOT version
+      if: github.event.inputs.release_type == 'snapshot'
+      run: |
+        sed -i "s/version = '.*'/version = '${{ github.event.inputs.version }}-SNAPSHOT'/" build.gradle
+        
+    - name: Run tests
+      run: ./gradlew clean test
+      
+    - name: Build and publish to Maven Central
+      env:
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      run: |
+        ./gradlew publish \
+          -Psigning.gnupg.keyName=${{ secrets.GPG_KEY_ID }} \
+          -Psigning.gnupg.passphrase=${{ secrets.GPG_PASSPHRASE }} \
+          -Psigning.gnupg.executable=gpg
+          
+    - name: Create Release Notes
+      if: github.event.inputs.release_type == 'release'
+      run: |
+        echo "## Shopify Spring SDK v${{ github.event.inputs.version }}" > release_notes.md
+        echo "" >> release_notes.md
+        echo "### Maven Central" >> release_notes.md
+        echo '```xml' >> release_notes.md
+        echo '<dependency>' >> release_notes.md
+        echo '    <groupId>io.github.astroryan</groupId>' >> release_notes.md
+        echo '    <artifactId>shopify-spring-sdk</artifactId>' >> release_notes.md
+        echo '    <version>${{ github.event.inputs.version }}</version>' >> release_notes.md
+        echo '</dependency>' >> release_notes.md
+        echo '```' >> release_notes.md
+        echo "" >> release_notes.md
+        echo "### Gradle" >> release_notes.md
+        echo '```gradle' >> release_notes.md
+        echo 'implementation "io.github.astroryan:shopify-spring-sdk:${{ github.event.inputs.version }}"' >> release_notes.md
+        echo '```' >> release_notes.md
+        
+    - name: Summary
+      run: |
+        echo "## 🚀 Maven Central Deployment" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ github.event.inputs.release_type }}" = "release" ]; then
+          echo "✅ Published Release: v${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "📦 [Maven Central](https://central.sonatype.com/artifact/io.github.astroryan/shopify-spring-sdk/${{ github.event.inputs.version }})" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "✅ Published Snapshot: v${{ github.event.inputs.version }}-SNAPSHOT" >> $GITHUB_STEP_SUMMARY
+          echo "📦 [OSSRH Snapshots](https://s01.oss.sonatype.org/content/repositories/snapshots/io/github/astroryan/shopify-spring-sdk/)" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,11 @@ plugins {
     id 'java-library'
     id 'jacoco'
     id 'maven-publish'
+    id 'signing'
 }
 
-group = 'com.shopify'
-version = '1.2.0'
+group = 'io.github.astroryan'
+version = '1.2.0-SNAPSHOT-40'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -55,7 +56,7 @@ dependencies {
     }
     
     // Jackson version management - ensure consistent versions
-    implementation enforcedPlatform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}")
+    implementation platform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}")
 
     // Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter'
@@ -193,11 +194,13 @@ sourceSets {
 publishing {
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/astroryan/shopify-sdk-java")
+            name = "OSSRH"
+            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
-                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
-                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+                username = project.findProperty("ossrhUsername") ?: System.getenv("OSSRH_USERNAME")
+                password = project.findProperty("ossrhPassword") ?: System.getenv("OSSRH_PASSWORD")
             }
         }
     }
@@ -205,6 +208,8 @@ publishing {
     publications {
         shopifySdk(MavenPublication) {
             from components.java
+            
+            artifactId = 'shopify-spring-sdk'
             
             pom {
                 name = 'Shopify Spring SDK'
@@ -236,10 +241,15 @@ publishing {
     }
 }
 
+// Signing configuration
+signing {
+    sign publishing.publications.shopifySdk
+}
+
 // Task to display publish info
 task publishInfo {
     doLast {
         println "Publishing ${project.group}:${project.name}:${project.version}"
-        println "To GitHub Packages: https://github.com/astroryan/shopify-sdk-java"
+        println "To Maven Central via OSSRH"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,16 @@
+# Gradle properties
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+
+# Project properties
+systemProp.file.encoding=UTF-8
+
+# Signing configuration (values will be provided via environment variables or command line)
+signing.keyId=
+signing.password=
+signing.secretKeyRingFile=
+
+# OSSRH credentials (values will be provided via environment variables or command line)
+ossrhUsername=
+ossrhPassword=


### PR DESCRIPTION
Sets up a GitHub Actions workflow to automatically publish the library to Maven Central.

This includes configuring the Gradle build file for Maven Central compatibility, such as updating the group ID and artifact ID, and adding signing configurations. It also sets up the workflow to handle both releases and snapshots, updating the version in the build file accordingly, generating release notes, and summarizing the deployment status.