### PR TITLE
Disables signing for GitHub Packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -264,6 +264,13 @@ if (project.hasProperty("signingKeyId") || project.hasProperty("signing.keyId"))
     }
 }
 
+// Disable signing for GitHub Packages
+tasks.withType(Sign) {
+    onlyIf {
+        gradle.taskGraph.hasTask("publishShopifySdkPublicationToOSSRHRepository")
+    }
+}
+
 // Task to display publish info
 task publishInfo {
     doLast {


### PR DESCRIPTION
Disables the signing process specifically when publishing to GitHub Packages. This prevents potential issues or conflicts during the publication process to the GitHub Packages registry.