### PR TITLE
Fixes signing configuration and adds debug info

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -67,6 +67,13 @@ jobs:
     - name: Run tests
       run: ./gradlew clean test
       
+    - name: Debug credentials
+      env:
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      run: |
+        echo "Maven Central username length: ${#MAVEN_CENTRAL_USERNAME}"
+        echo "GPG Key ID: ${{ secrets.GPG_KEY_ID }}"
+        
     - name: Build and publish to Maven Central
       env:
         MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
@@ -78,7 +85,7 @@ jobs:
           -PsigningKeyId=${{ secrets.GPG_KEY_ID }} \
           -PsigningPassword=${{ secrets.GPG_PASSPHRASE }} \
           -PsigningKey="$GPG_SIGNING_KEY" \
-          --info
+          --info --stacktrace
           
     - name: Create Release Notes
       if: github.event.inputs.release_type == 'release'

--- a/build.gradle
+++ b/build.gradle
@@ -203,7 +203,7 @@ publishing {
                 password = project.findProperty("mavenCentralPassword") ?: System.getenv("MAVEN_CENTRAL_PASSWORD")
             }
         }
-        maven {
+         maven {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/astroryan/shopify-sdk-java")
             credentials {
@@ -249,19 +249,17 @@ publishing {
     }
 }
 
-// Signing configuration - only for Maven Central
-if (project.hasProperty("signingKeyId") || project.hasProperty("signing.keyId")) {
-    signing {
-        def signingKeyId = findProperty("signingKeyId") ?: findProperty("signing.keyId")
-        def signingPassword = findProperty("signingPassword") ?: findProperty("signing.password")
-        def signingKey = findProperty("signingKey") ?: findProperty("signing.key")
-        
-        if (signingKeyId && signingPassword && signingKey) {
-            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-        }
-        
-        sign publishing.publications.shopifySdk
+// Signing configuration
+signing {
+    def signingKeyId = findProperty("signingKeyId")
+    def signingPassword = findProperty("signingPassword")
+    def signingKey = findProperty("signingKey")
+    
+    if (signingKeyId && signingPassword && signingKey) {
+        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     }
+    
+    sign publishing.publications.shopifySdk
 }
 
 // Disable signing for GitHub Packages


### PR DESCRIPTION
Fixes the signing configuration to properly use in-memory PGP keys by removing the Maven Central conditional.

Adds a debug step in the publishing workflow to print the length of the Maven Central username and the GPG Key ID to aid in troubleshooting authentication issues. Also adds stacktrace to the gradle command to help debug.